### PR TITLE
Bugfix/libnetconf libtool

### DIFF
--- a/package/libnetconf/libnetconf.mk
+++ b/package/libnetconf/libnetconf.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBNETCONF_VERSION = 6351e224b4e67f0ba0265f27e1aa4707060036b0
+LIBNETCONF_VERSION = master
 LIBNETCONF_SITE = https://github.com/CESNET/libnetconf.git
 LIBNETCONF_SITE_METHOD = git
 LIBNETCONF_INSTALL_STAGING = YES

--- a/package/libnetconf/libnetconf.mk
+++ b/package/libnetconf/libnetconf.mk
@@ -16,6 +16,7 @@ LIBNETCONF_DEPENDENCIES  = openssl libgcrypt libssh libxslt ncurses readline
 LIBNETCONF_DEPENDENCIES += dbus host-pyang host-h-python-libxml2 libcurl
 LIBNETCONF_CONF_ENV += PKG_CONFIG=$(HOST_DIR)/usr/bin/pkg-config
 LIBNETCONF_CONF_ENV += enable_validation=no
+LIBNETCONF_AUTORECONF := YES
 
 define LIBNETCONF_INSTALL_STAGING_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/dev-tools/lnctool/lnctool $(HOST_DIR)/usr/bin


### PR DESCRIPTION
This fixes the build error reported in https://github.com/openil/openil/issues/13 and reverts the previous workaround (https://github.com/openil/openil/commit/e6ecfaf2aa429b5051684851b4892e5672d97b74):

```
libtool: Version mismatch error.  This is libtool 2.4.2, but the                                                                                                                                           
libtool: definition of this LT_INIT comes from libtool 2.4.6.                                                                                                                                              
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.2                                                                                                                                     
libtool: and run autoconf again.
```