### PR TITLE
Fix download location for pcre packages

### DIFF
--- a/package/pcre/pcre.mk
+++ b/package/pcre/pcre.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PCRE_VERSION = 8.43
-PCRE_SITE = https://ftp.pcre.org/pub/pcre
+PCRE_SITE = https://sourceforge.net/projects/pcre/files/pcre/$(PCRE_VERSION)
 PCRE_SOURCE = pcre-$(PCRE_VERSION).tar.bz2
 PCRE_LICENSE = BSD-3-Clause
 PCRE_LICENSE_FILES = LICENCE

--- a/package/pcre2/pcre2.mk
+++ b/package/pcre2/pcre2.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PCRE2_VERSION = 10.33
-PCRE2_SITE = https://ftp.pcre.org/pub/pcre
+PCRE2_SITE = https://sourceforge.net/projects/pcre/files/pcre2/$(PCRE2_VERSION)
 PCRE2_SOURCE = pcre2-$(PCRE2_VERSION).tar.bz2
 PCRE2_LICENSE = BSD-3-Clause
 PCRE2_LICENSE_FILES = LICENCE


### PR DESCRIPTION
The old FTP server is offline and the official page suggest to retrieve old packages from their sourceforge mirror.

Fixes #106 